### PR TITLE
chore: Add pls versions manifest

### DIFF
--- a/.pls/versions.json
+++ b/.pls/versions.json
@@ -1,0 +1,6 @@
+{
+  ".": "0.1.0",
+  "packages/json-pointer": "0.1.0",
+  "packages/json-schema": "0.1.0",
+  "packages/openapi": "0.1.0"
+}


### PR DESCRIPTION
Initialize .pls/versions.json for tracking package versions across the workspace. This manifest is used by the pls release tool to manage lock-step versioning.