### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dgellow/steady/security/code-scanning/3](https://github.com/dgellow/steady/security/code-scanning/3)

To fix this, add an explicit `permissions` block to the root of `.github/workflows/ci.yml`. This block should specify the minimal required permissions; in this case, `contents: read` is the safest baseline and will satisfy most workflows that only need to checkout code and run tests/lints. Place this block immediately after the `name` field and before the `on` block, to ensure it applies to all jobs in the workflow. No further changes are needed unless specific jobs need extra permissions, which does not appear required from the shown steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
