### PR TITLE
feat: Add npm publishing with platform-specific packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,32 @@ jobs:
 
       - name: Run OpenAPI directory tests
         run: deno task test:specs
+
+  test-npm-build:
+    name: Test npm Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build npm packages (linux-x64 only)
+        run: deno run -A scripts/build_npm.ts --platform linux-x64
+
+      - name: Install and test CLI
+        run: |
+          cd /tmp
+          npm init -y
+          npm install ${{ github.workspace }}/npm/cli ${{ github.workspace }}/npm/cli-linux-x64
+          npx steady validate ${{ github.workspace }}/tests/specs/simple.yaml
+          npx steady --help

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,3 +25,55 @@ jobs:
 
       - name: Publish all packages to JSR
         run: deno publish
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Build npm packages
+        run: deno run -A scripts/build_npm.ts
+
+      # Publish platform-specific packages first (main package depends on them)
+      - name: Publish @stdy/cli-linux-x64
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli-linux-x64
+
+      - name: Publish @stdy/cli-linux-arm64
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli-linux-arm64
+
+      - name: Publish @stdy/cli-darwin-x64
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli-darwin-x64
+
+      - name: Publish @stdy/cli-darwin-arm64
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli-darwin-arm64
+
+      - name: Publish @stdy/cli-win32-x64
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli-win32-x64
+
+      # Publish main package last
+      - name: Publish @stdy/cli
+        run: npm publish --access public --provenance
+        working-directory: ./npm/cli

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ analysis-report.json
 # SDK test directories (cloned for testing)
 openai-python/
 sdk-tests/
+
+# npm build output
+npm/

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@ and generates responses from schemas or examples.
 
 ## Installation
 
-Requires [Deno](https://deno.land/) 2.x.
-
 ```bash
-# Run directly
-deno run -A jsr:@steady/cli api.yaml
+# npm (recommended)
+npm install -g @stdy/cli
 
-# Or install globally
+# Or with Deno
 deno install -gAn steady jsr:@steady/cli
 ```
 

--- a/cmd/steady.ts
+++ b/cmd/steady.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env -S deno run --allow-read --allow-net --allow-env
-
 import { parseArgs } from "@std/cli/parse-args";
 import { parseSpecFromFile, SteadyError } from "@steady/openapi";
 import { LogLevel } from "../src/logging/mod.ts";

--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,20 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@deno/dnt@0.42.3": "0.42.3",
     "jsr:@std/assert@^1.0.16": "1.0.16",
     "jsr:@std/cli@^1.0.24": "1.0.24",
     "jsr:@std/dotenv@~0.225.5": "0.225.5",
+    "jsr:@std/fmt@1": "1.0.8",
+    "jsr:@std/fs@1": "1.0.20",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.3",
+    "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/yaml@*": "1.0.10",
     "jsr:@std/yaml@^1.0.10": "1.0.10",
+    "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
+    "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@hyperjump/json-schema@*": "1.17.2_@hyperjump+browser@1.3.1",
     "npm:@types/node@*": "22.15.15",
     "npm:fullscreen-ink@*": "0.0.2_react@19.1.0",
@@ -18,6 +26,19 @@
     "npm:react@18": "18.3.1"
   },
   "jsr": {
+    "@david/code-block-writer@13.0.3": {
+      "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
+    },
+    "@deno/dnt@0.42.3": {
+      "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
+      "dependencies": [
+        "jsr:@david/code-block-writer",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/path@1",
+        "jsr:@ts-morph/bootstrap"
+      ]
+    },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
       "dependencies": [
@@ -33,11 +54,40 @@
     "@std/dotenv@0.225.5": {
       "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
     },
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
+    "@std/fs@1.0.20": {
+      "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
+      "dependencies": [
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.3"
+      ]
+    },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@1.1.3": {
+      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/yaml@1.0.10": {
       "integrity": "245706ea3511cc50c8c6d00339c23ea2ffa27bd2c7ea5445338f8feff31fa58e"
+    },
+    "@ts-morph/bootstrap@0.27.0": {
+      "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
+      "dependencies": [
+        "jsr:@ts-morph/common"
+      ]
+    },
+    "@ts-morph/common@0.27.0": {
+      "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
+      "dependencies": [
+        "jsr:@std/fs",
+        "jsr:@std/path@1"
+      ]
     }
   },
   "npm": {

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * Build script for publishing the CLI to npm as @stdy/cli
+ * Creates platform-specific packages like esbuild does:
+ *   @stdy/cli           - Main package with wrapper (tiny)
+ *   @stdy/cli-linux-x64 - Linux x64 binary
+ *   @stdy/cli-linux-arm64 - Linux ARM64 binary
+ *   @stdy/cli-darwin-x64 - macOS Intel binary
+ *   @stdy/cli-darwin-arm64 - macOS Apple Silicon binary
+ *   @stdy/cli-win32-x64 - Windows x64 binary
+ *
+ * Usage:
+ *   deno run -A scripts/build_npm.ts              # Build all platforms
+ *   deno run -A scripts/build_npm.ts --platform linux-x64  # Build only linux-x64
+ */
+
+import { parseArgs } from "@std/cli/parse-args";
+
+const args = parseArgs(Deno.args, {
+  string: ["platform"],
+});
+
+// Get version from deno.json
+const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
+const version = args._[0] as string || denoJson.version;
+
+if (!version) {
+  console.error(
+    "Error: No version specified. Pass version as argument or ensure deno.json has a version field.",
+  );
+  Deno.exit(1);
+}
+
+console.log(`Building @stdy/cli version ${version}...`);
+
+// Clean output directory
+try {
+  await Deno.remove("./npm", { recursive: true });
+} catch {
+  // Directory doesn't exist, ignore
+}
+
+// Platform configurations
+const allPlatforms = [
+  {
+    target: "x86_64-unknown-linux-gnu",
+    pkg: "@stdy/cli-linux-x64",
+    os: "linux",
+    cpu: "x64",
+    binName: "steady",
+  },
+  {
+    target: "aarch64-unknown-linux-gnu",
+    pkg: "@stdy/cli-linux-arm64",
+    os: "linux",
+    cpu: "arm64",
+    binName: "steady",
+  },
+  {
+    target: "x86_64-apple-darwin",
+    pkg: "@stdy/cli-darwin-x64",
+    os: "darwin",
+    cpu: "x64",
+    binName: "steady",
+  },
+  {
+    target: "aarch64-apple-darwin",
+    pkg: "@stdy/cli-darwin-arm64",
+    os: "darwin",
+    cpu: "arm64",
+    binName: "steady",
+  },
+  {
+    target: "x86_64-pc-windows-msvc",
+    pkg: "@stdy/cli-win32-x64",
+    os: "win32",
+    cpu: "x64",
+    binName: "steady.exe",
+  },
+];
+
+// Filter platforms if --platform flag is provided
+const platforms = args.platform
+  ? allPlatforms.filter((p) => `${p.os}-${p.cpu}` === args.platform)
+  : allPlatforms;
+
+if (platforms.length === 0) {
+  console.error(`Error: Unknown platform "${args.platform}"`);
+  console.error(
+    "Valid platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64",
+  );
+  Deno.exit(1);
+}
+
+// Create platform-specific packages
+for (const platform of platforms) {
+  const pkgDir = `./npm/${platform.pkg.replace("@stdy/", "")}`;
+  await Deno.mkdir(`${pkgDir}/bin`, { recursive: true });
+
+  console.log(`[build] Compiling for ${platform.target}...`);
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "compile",
+      "--allow-read",
+      "--allow-write",
+      "--allow-net",
+      "--allow-env",
+      "--target",
+      platform.target,
+      "--output",
+      `${pkgDir}/bin/${platform.binName}`,
+      "./cmd/steady.ts",
+    ],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const result = await cmd.output();
+  if (!result.success) {
+    console.error(`Failed to compile for ${platform.target}`);
+    Deno.exit(1);
+  }
+
+  // Create package.json for this platform
+  const pkgJson = {
+    name: platform.pkg,
+    version,
+    description:
+      `Platform-specific binary for @stdy/cli (${platform.os}-${platform.cpu})`,
+    license: "Elastic-2.0",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/stainless-api/steady.git",
+    },
+    os: [platform.os],
+    cpu: [platform.cpu],
+    bin: {
+      steady: `./bin/${platform.binName}`,
+    },
+  };
+
+  await Deno.writeTextFile(
+    `${pkgDir}/package.json`,
+    JSON.stringify(pkgJson, null, 2) + "\n",
+  );
+
+  // Show binary size
+  const stat = await Deno.stat(`${pkgDir}/bin/${platform.binName}`);
+  const sizeMB = (stat.size / 1024 / 1024).toFixed(1);
+  console.log(`  ${platform.pkg}: ${sizeMB} MB`);
+}
+
+// Create main @stdy/cli package
+console.log("\n[build] Creating main @stdy/cli package...");
+const mainPkgDir = "./npm/cli";
+await Deno.mkdir(mainPkgDir, { recursive: true });
+
+// Create the JavaScript wrapper
+const wrapperCode = `#!/usr/bin/env node
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const platform = process.platform;
+const arch = process.arch;
+
+const PLATFORMS = {
+  "linux-x64": "cli-linux-x64",
+  "linux-arm64": "cli-linux-arm64",
+  "darwin-x64": "cli-darwin-x64",
+  "darwin-arm64": "cli-darwin-arm64",
+  "win32-x64": "cli-win32-x64",
+};
+
+const key = \`\${platform}-\${arch}\`;
+const pkgSuffix = PLATFORMS[key];
+
+if (!pkgSuffix) {
+  console.error(\`Unsupported platform: \${key}\`);
+  console.error("Please use Deno directly: deno run -A jsr:@steady/cli");
+  process.exit(1);
+}
+
+const binName = platform === "win32" ? "steady.exe" : "steady";
+let binPath;
+
+// Try multiple locations:
+// 1. Sibling directory (for local dev/testing)
+// 2. node_modules (for installed package)
+const locations = [
+  // Local dev: ../cli-linux-x64/bin/steady
+  path.join(__dirname, "..", pkgSuffix, "bin", binName),
+  // Installed: node_modules/@stdy/cli-linux-x64/bin/steady
+  path.join(__dirname, "..", "..", pkgSuffix, "bin", binName),
+];
+
+for (const loc of locations) {
+  if (fs.existsSync(loc)) {
+    binPath = loc;
+    break;
+  }
+}
+
+if (!binPath) {
+  // Try require.resolve as fallback
+  try {
+    const pkgPath = require.resolve(\`@stdy/\${pkgSuffix}/package.json\`);
+    const pkgDir = path.dirname(pkgPath);
+    binPath = path.join(pkgDir, "bin", binName);
+  } catch (e) {
+    console.error(\`Failed to find binary for \${key}\`);
+    console.error("Try reinstalling: npm install @stdy/cli");
+    process.exit(1);
+  }
+}
+
+try {
+  execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+} catch (e) {
+  if (e.status !== undefined) {
+    process.exit(e.status);
+  }
+  throw e;
+}
+`;
+
+await Deno.writeTextFile(`${mainPkgDir}/steady.js`, wrapperCode);
+
+// Create main package.json with optionalDependencies
+const mainPkgJson = {
+  name: "@stdy/cli",
+  version,
+  description:
+    "OpenAPI 3 mock server. Validates SDKs against OpenAPI specs with clear error attribution.",
+  license: "Elastic-2.0",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/stainless-api/steady.git",
+  },
+  bugs: {
+    url: "https://github.com/stainless-api/steady/issues",
+  },
+  homepage: "https://github.com/stainless-api/steady#readme",
+  keywords: [
+    "openapi",
+    "mock-server",
+    "api-testing",
+    "sdk-testing",
+    "json-schema",
+    "validation",
+  ],
+  bin: {
+    steady: "./steady.js",
+  },
+  files: ["steady.js"],
+  engines: {
+    node: ">=14.0.0",
+  },
+  optionalDependencies: {
+    "@stdy/cli-linux-x64": version,
+    "@stdy/cli-linux-arm64": version,
+    "@stdy/cli-darwin-x64": version,
+    "@stdy/cli-darwin-arm64": version,
+    "@stdy/cli-win32-x64": version,
+  },
+};
+
+await Deno.writeTextFile(
+  `${mainPkgDir}/package.json`,
+  JSON.stringify(mainPkgJson, null, 2) + "\n",
+);
+
+// Copy README and LICENSE to main package
+await Deno.copyFile("LICENSE", `${mainPkgDir}/LICENSE`);
+await Deno.copyFile("README.md", `${mainPkgDir}/README.md`);
+
+console.log(`
+Build complete! Output in ./npm
+
+Packages created:
+  npm/cli/           - @stdy/cli (main package)
+  npm/cli-linux-x64/ - @stdy/cli-linux-x64
+  npm/cli-linux-arm64/ - @stdy/cli-linux-arm64
+  npm/cli-darwin-x64/ - @stdy/cli-darwin-x64
+  npm/cli-darwin-arm64/ - @stdy/cli-darwin-arm64
+  npm/cli-win32-x64/ - @stdy/cli-win32-x64
+
+To publish all packages:
+  for dir in npm/*/; do (cd "\$dir" && npm publish --access public); done
+`);

--- a/src/logging/ink-logger.tsx
+++ b/src/logging/ink-logger.tsx
@@ -1,5 +1,3 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-sys --allow-net
-
 import React, { useEffect, useState } from "npm:react@18";
 import { Box, render, Text, useApp, useInput, useStdout } from "npm:ink@5";
 // import fullscreen from "npm:fullscreen-ink"; // Not used currently

--- a/src/logging/simple-logger.ts
+++ b/src/logging/simple-logger.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-sys
-
 import type { LogLevel, StoredRequest } from "./types.ts";
 import { RequestLogger, type ValidationResult } from "./logger.ts";
 


### PR DESCRIPTION
Uses deno compile to create standalone binaries for each platform,
following esbuild's approach with optionalDependencies.

Packages:
- @stdy/cli - Main wrapper package
- @stdy/cli-linux-x64, cli-linux-arm64
- @stdy/cli-darwin-x64, cli-darwin-arm64
- @stdy/cli-win32-x64

Uses OIDC with --provenance for secure npm publishing (no tokens needed).