### PR TITLE
chore: always use latest pls version in CI workflows

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -27,9 +27,8 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-          cache: true
 
       - name: Sync PR with selected version
-        run: deno run -A --reload=jsr:@dgellow/pls jsr:@dgellow/pls sync --pr=${{ github.event.pull_request.number }}
+        run: deno run -A jsr:@dgellow/pls sync --pr=${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.PLS_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-          cache: true
 
       - name: Configure Git
         run: |
@@ -45,11 +44,11 @@ jobs:
       # - If tag exists: no-op (success)
       # - If tag missing: creates it (self-heals from previous failure)
       - name: Create release (if release commit merged)
-        run: deno run -A --reload=jsr:@dgellow/pls jsr:@dgellow/pls release
+        run: deno run -A jsr:@dgellow/pls release
         env:
           GITHUB_TOKEN: ${{ secrets.PLS_RELEASE_TOKEN }}
 
       - name: Create/update release PR
-        run: deno run -A --reload=jsr:@dgellow/pls jsr:@dgellow/pls prep --execute
+        run: deno run -A jsr:@dgellow/pls prep --execute
         env:
           GITHUB_TOKEN: ${{ secrets.PLS_RELEASE_TOKEN }}


### PR DESCRIPTION
Add --reload=jsr:@dgellow/pls flag to force Deno to fetch the latest
version of pls from JSR instead of using a cached version.