### PR TITLE
feat: add streaming support for NDJSON and SSE responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,17 @@ validation errors are logged but responses are still returned.
 
 Override server behavior for individual requests:
 
-| Header                         | Description                                       |
-| ------------------------------ | ------------------------------------------------- |
-| `X-Steady-Mode`                | Override validation mode: `strict` or `relaxed`   |
-| `X-Steady-Query-Array-Format`  | Override array query param serialization format   |
-| `X-Steady-Query-Object-Format` | Override object query param serialization format  |
-| `X-Steady-Array-Size`          | Override array size (sets both min and max)       |
-| `X-Steady-Array-Min`           | Override minimum array size                       |
-| `X-Steady-Array-Max`           | Override maximum array size                       |
-| `X-Steady-Seed`                | Override random seed (`-1` for non-deterministic) |
+| Header                         | Description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `X-Steady-Mode`                | Override validation mode: `strict` or `relaxed`      |
+| `X-Steady-Query-Array-Format`  | Override array query param serialization format      |
+| `X-Steady-Query-Object-Format` | Override object query param serialization format     |
+| `X-Steady-Array-Size`          | Override array size (sets both min and max)          |
+| `X-Steady-Array-Min`           | Override minimum array size                          |
+| `X-Steady-Array-Max`           | Override maximum array size                          |
+| `X-Steady-Seed`                | Override random seed (`-1` for non-deterministic)    |
+| `X-Steady-Stream-Count`        | Number of items to stream (default: 5)               |
+| `X-Steady-Stream-Interval-Ms`  | Interval between streamed items in ms (default: 100) |
 
 ```bash
 # Force strict validation
@@ -190,6 +192,132 @@ Informational headers returned by the server:
 | `X-Steady-Mode`           | The validation mode used for this request             |
 | `X-Steady-Matched-Path`   | The OpenAPI path pattern that matched                 |
 | `X-Steady-Example-Source` | How the response was generated: `generated` or `none` |
+| `X-Steady-Streaming`      | Set to `true` for streaming responses                 |
+
+## Streaming Responses
+
+Steady supports streaming responses for NDJSON and Server-Sent Events (SSE):
+
+| Content Type           | Format | Description            |
+| ---------------------- | ------ | ---------------------- |
+| `application/x-ndjson` | NDJSON | Newline-delimited JSON |
+| `application/jsonl`    | NDJSON | JSON Lines             |
+| `application/json-seq` | NDJSON | JSON Sequence          |
+| `text/event-stream`    | SSE    | Server-Sent Events     |
+
+### Streaming Headers
+
+| Header                        | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `X-Steady-Stream-Count`       | Number of items to stream (default: 5)      |
+| `X-Steady-Stream-Interval-Ms` | Interval between items in ms (default: 100) |
+
+```bash
+# Stream 10 items with 50ms delay
+curl -H "X-Steady-Stream-Count: 10" \
+     -H "X-Steady-Stream-Interval-Ms: 50" \
+     http://localhost:3000/events
+```
+
+### NDJSON Example
+
+```yaml
+/metrics:
+  get:
+    responses:
+      "200":
+        content:
+          application/x-ndjson:
+            schema:
+              type: object
+              properties:
+                id: { type: integer }
+                value: { type: number }
+```
+
+Output:
+
+```
+{"id":1,"value":42.5,"_stream":{"index":0,"total":5,"timestamp":"..."}}
+{"id":2,"value":43.1,"_stream":{"index":1,"total":5,"timestamp":"..."}}
+...
+```
+
+### SSE with Event Sequences
+
+Define realistic SSE flows with different event types using array examples:
+
+```yaml
+/events:
+  get:
+    responses:
+      "200":
+        content:
+          text/event-stream:
+            example:
+              - event: start
+                data: { status: "processing" }
+              - event: progress
+                data: { percent: 50 }
+              - event: progress
+                data: { percent: 100 }
+              - event: complete
+                data: { result: "success" }
+```
+
+Output:
+
+```
+id: 0
+event: start
+data: {"status":"processing"}
+
+id: 1
+event: progress
+data: {"percent":50}
+
+id: 2
+event: progress
+data: {"percent":100}
+
+id: 3
+event: complete
+data: {"result":"success"}
+```
+
+SSE events support these fields:
+
+- `event` - Event type name (default: "message"; set to `null` or `""` to omit)
+- `data` - Event payload (required; strings output as-is, objects JSON-encoded)
+- `id` - Custom event ID (auto-generated if omitted; set to `null` to omit)
+- `retry` - Reconnection timeout in milliseconds
+
+If the last event isn't `done`, `complete`, or `end`, Steady automatically
+appends a `done` event to signal stream completion.
+
+### OpenAI-Style SSE
+
+For APIs like OpenAI that use data-only terminal events, set `event` and `id` to
+`null`:
+
+```yaml
+example:
+  - event: message
+    data: { delta: { content: "Hello" } }
+  - event: null
+    id: null
+    data: "[DONE]"
+```
+
+Output:
+
+```
+id: 0
+event: message
+data: {"delta":{"content":"Hello"}}
+
+data: [DONE]
+```
 
 ## Special Endpoints
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,13 @@ import {
   matchCompiledPath,
   type PathSegment,
 } from "./path-matcher.ts";
+import {
+  createStreamingResponse,
+  getStreamFormat,
+  isStreamingContentType,
+  parseStreamingOptions,
+  type StreamingOptions,
+} from "./streaming.ts";
 
 // ANSI colors for startup message
 const BOLD = "\x1b[1m";
@@ -320,6 +327,9 @@ export class MockServer {
       }
 
       const generatorOptions = this.getEffectiveGeneratorOptions(req);
+      const streamingOptions = parseStreamingOptions(req);
+      streamingOptions.generatorOptions = generatorOptions;
+
       const response = this.generateResponse(
         operation,
         statusCode,
@@ -327,6 +337,7 @@ export class MockServer {
         method,
         pathPattern,
         generatorOptions,
+        streamingOptions,
       );
 
       const timing = Math.round(performance.now() - startTime);
@@ -512,6 +523,7 @@ export class MockServer {
     method: string,
     pathPattern: string,
     generatorOptions: GenerateOptions,
+    streamingOptions: StreamingOptions,
   ): Response {
     const responseObjOrRef = operation.responses[statusCode];
     if (!responseObjOrRef) {
@@ -547,6 +559,7 @@ export class MockServer {
         method,
         pathPattern,
         generatorOptions,
+        streamingOptions,
       );
     }
 
@@ -557,6 +570,7 @@ export class MockServer {
       method,
       pathPattern,
       generatorOptions,
+      streamingOptions,
     );
   }
 
@@ -570,6 +584,7 @@ export class MockServer {
     method: string,
     pathPattern: string,
     generatorOptions: GenerateOptions,
+    streamingOptions: StreamingOptions,
   ): Response {
     let body: unknown = null;
     let contentType = "application/json";
@@ -582,6 +597,26 @@ export class MockServer {
           `[Steady] Warning: Response for ${method.toUpperCase()} ${path} has empty content object. ` +
             `Using default application/json with no body.`,
         );
+      }
+
+      // Check for streaming content types first
+      const streamingContentType = contentKeys.find(isStreamingContentType);
+      if (streamingContentType) {
+        const mediaType = responseObj.content[streamingContentType];
+        if (mediaType?.schema || mediaType?.example) {
+          // Pass example to streaming options for SSE event sequences
+          if (mediaType.example !== undefined) {
+            streamingOptions.example = mediaType.example;
+          }
+          return this.generateStreamingResponse(
+            mediaType.schema,
+            pathPattern,
+            method,
+            statusCode,
+            streamingContentType,
+            streamingOptions,
+          );
+        }
       }
 
       // Prefer JSON, then any other content type
@@ -664,6 +699,57 @@ export class MockServer {
         headers,
       },
     );
+  }
+
+  /**
+   * Generate a streaming response (NDJSON or SSE)
+   */
+  private generateStreamingResponse(
+    schema: unknown,
+    pathPattern: string,
+    method: string,
+    statusCode: string,
+    contentType: string,
+    streamingOptions: StreamingOptions,
+  ): Response {
+    const format = getStreamFormat(contentType);
+    if (!format) {
+      // Fallback to JSON if format detection fails
+      throw new Error(`Unknown streaming format: ${contentType}`);
+    }
+
+    const schemaPointer = `#/paths/${
+      this.escapePointer(pathPattern)
+    }/${method}/responses/${statusCode}/content/${
+      this.escapePointer(contentType)
+    }/schema`;
+
+    const stream = createStreamingResponse(
+      this.document.schemas,
+      schema,
+      schemaPointer,
+      format,
+      streamingOptions,
+    );
+
+    const headers = new Headers({
+      "Content-Type": contentType,
+      [HEADERS.MATCHED_PATH]: pathPattern,
+      [HEADERS.EXAMPLE_SOURCE]: "generated",
+      [HEADERS.STREAMING]: "true",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    });
+
+    // For SSE, add specific headers
+    if (format === "sse") {
+      headers.set("X-Accel-Buffering", "no"); // Disable nginx buffering
+    }
+
+    return new Response(stream, {
+      status: parseInt(statusCode, 10),
+      headers,
+    });
   }
 
   /**

--- a/src/streaming.test.ts
+++ b/src/streaming.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Tests for streaming response generator (NDJSON and SSE)
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  createStreamingResponse,
+  getStreamFormat,
+  isSSEEventSequence,
+  isStreamingContentType,
+  parseStreamingOptions,
+  STREAMING_CONTENT_TYPES,
+} from "./streaming.ts";
+import { SchemaRegistry } from "@steady/json-schema";
+
+Deno.test("isStreamingContentType: recognizes NDJSON content types", () => {
+  assertEquals(isStreamingContentType("application/x-ndjson"), true);
+  assertEquals(isStreamingContentType("application/jsonl"), true);
+  assertEquals(isStreamingContentType("application/json-seq"), true);
+});
+
+Deno.test("isStreamingContentType: recognizes SSE content type", () => {
+  assertEquals(isStreamingContentType("text/event-stream"), true);
+});
+
+Deno.test("isStreamingContentType: rejects non-streaming types", () => {
+  assertEquals(isStreamingContentType("application/json"), false);
+  assertEquals(isStreamingContentType("text/plain"), false);
+  assertEquals(isStreamingContentType("text/html"), false);
+});
+
+Deno.test("isStreamingContentType: handles content type with parameters", () => {
+  assertEquals(
+    isStreamingContentType("application/x-ndjson; charset=utf-8"),
+    true,
+  );
+  assertEquals(
+    isStreamingContentType("text/event-stream; charset=utf-8"),
+    true,
+  );
+});
+
+Deno.test("isStreamingContentType: is case insensitive", () => {
+  assertEquals(isStreamingContentType("APPLICATION/X-NDJSON"), true);
+  assertEquals(isStreamingContentType("Text/Event-Stream"), true);
+});
+
+Deno.test("getStreamFormat: returns ndjson for NDJSON types", () => {
+  assertEquals(getStreamFormat("application/x-ndjson"), "ndjson");
+  assertEquals(getStreamFormat("application/jsonl"), "ndjson");
+  assertEquals(getStreamFormat("application/json-seq"), "ndjson");
+});
+
+Deno.test("getStreamFormat: returns sse for SSE type", () => {
+  assertEquals(getStreamFormat("text/event-stream"), "sse");
+});
+
+Deno.test("getStreamFormat: returns null for non-streaming types", () => {
+  assertEquals(getStreamFormat("application/json"), null);
+  assertEquals(getStreamFormat("text/plain"), null);
+});
+
+Deno.test("parseStreamingOptions: parses count header", () => {
+  const req = new Request("http://localhost/test", {
+    headers: { "X-Steady-Stream-Count": "10" },
+  });
+  const options = parseStreamingOptions(req);
+  assertEquals(options.count, 10);
+});
+
+Deno.test("parseStreamingOptions: parses interval header", () => {
+  const req = new Request("http://localhost/test", {
+    headers: { "X-Steady-Stream-Interval-Ms": "200" },
+  });
+  const options = parseStreamingOptions(req);
+  assertEquals(options.interval, 200);
+});
+
+Deno.test("parseStreamingOptions: ignores invalid count", () => {
+  const req = new Request("http://localhost/test", {
+    headers: { "X-Steady-Stream-Count": "abc" },
+  });
+  const options = parseStreamingOptions(req);
+  assertEquals(options.count, undefined);
+});
+
+Deno.test("parseStreamingOptions: rejects count over 1000", () => {
+  const req = new Request("http://localhost/test", {
+    headers: { "X-Steady-Stream-Count": "5000" },
+  });
+  const options = parseStreamingOptions(req);
+  assertEquals(options.count, undefined);
+});
+
+Deno.test("parseStreamingOptions: rejects negative interval", () => {
+  const req = new Request("http://localhost/test", {
+    headers: { "X-Steady-Stream-Interval-Ms": "-100" },
+  });
+  const options = parseStreamingOptions(req);
+  assertEquals(options.interval, undefined);
+});
+
+Deno.test("createStreamingResponse: generates NDJSON stream", async () => {
+  const doc = {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      name: { type: "string" },
+    },
+    required: ["id", "name"],
+  };
+
+  const registry = new SchemaRegistry({ schema: doc });
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "ndjson",
+    { count: 3, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  // Split by newlines and parse
+  const lines = fullText.trim().split("\n");
+  assertEquals(lines.length, 3);
+
+  // Each line should be valid JSON
+  for (const line of lines) {
+    const parsed = JSON.parse(line);
+    assertEquals(typeof parsed._stream, "object");
+    assertEquals(typeof parsed._stream.index, "number");
+    assertEquals(typeof parsed._stream.total, "number");
+    assertEquals(parsed._stream.total, 3);
+  }
+});
+
+Deno.test("createStreamingResponse: generates SSE stream", async () => {
+  const doc = {
+    type: "object",
+    properties: {
+      value: { type: "integer" },
+    },
+  };
+
+  const registry = new SchemaRegistry({ schema: doc });
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { count: 2, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  // SSE format should have id, event, and data lines
+  assertStringIncludes(fullText, "id: 0");
+  assertStringIncludes(fullText, "event: message");
+  assertStringIncludes(fullText, "data: {");
+  // Should end with done event
+  assertStringIncludes(fullText, "event: done");
+});
+
+Deno.test("createStreamingResponse: uses deterministic seeds", async () => {
+  const doc = {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+    },
+  };
+
+  const registry = new SchemaRegistry({ schema: doc });
+
+  // Generate twice with same seed
+  const stream1 = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "ndjson",
+    { count: 2, interval: 0, generatorOptions: { seed: 42 } },
+  );
+
+  const stream2 = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "ndjson",
+    { count: 2, interval: 0, generatorOptions: { seed: 42 } },
+  );
+
+  const readAll = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value);
+    }
+    return text;
+  };
+
+  const text1 = await readAll(stream1);
+  const text2 = await readAll(stream2);
+
+  // Parse and compare data (ignoring timestamps which will differ)
+  const lines1 = text1.trim().split("\n").map((l) => {
+    const obj = JSON.parse(l);
+    delete obj._stream.timestamp;
+    return obj;
+  });
+  const lines2 = text2.trim().split("\n").map((l) => {
+    const obj = JSON.parse(l);
+    delete obj._stream.timestamp;
+    return obj;
+  });
+
+  assertEquals(lines1, lines2);
+});
+
+Deno.test("createStreamingResponse: handles $ref schemas", async () => {
+  const doc = {
+    components: {
+      schemas: {
+        Event: {
+          type: "object",
+          properties: {
+            type: { type: "string" },
+          },
+        },
+      },
+    },
+  };
+
+  const registry = new SchemaRegistry(doc);
+  const stream = createStreamingResponse(
+    registry,
+    { $ref: "#/components/schemas/Event" },
+    "#/test",
+    "ndjson",
+    { count: 1, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  const lines = fullText.trim().split("\n");
+  assertEquals(lines.length, 1);
+  const parsed = JSON.parse(lines[0]!);
+  assertEquals(typeof parsed._stream, "object");
+});
+
+Deno.test("STREAMING_CONTENT_TYPES: contains all expected types", () => {
+  assertEquals(STREAMING_CONTENT_TYPES.includes("application/x-ndjson"), true);
+  assertEquals(STREAMING_CONTENT_TYPES.includes("application/jsonl"), true);
+  assertEquals(STREAMING_CONTENT_TYPES.includes("application/json-seq"), true);
+  assertEquals(STREAMING_CONTENT_TYPES.includes("text/event-stream"), true);
+});
+
+// SSE Example Sequence Tests
+
+Deno.test("isSSEEventSequence: recognizes valid event sequences", () => {
+  const validSequence = [
+    { event: "message", data: { text: "Hello" } },
+    { event: "progress", data: { percent: 50 } },
+    { event: "done", data: {} },
+  ];
+  assertEquals(isSSEEventSequence(validSequence), true);
+});
+
+Deno.test("isSSEEventSequence: accepts events with only data field", () => {
+  const dataOnly = [
+    { data: { text: "Hello" } },
+    { data: { text: "World" } },
+  ];
+  assertEquals(isSSEEventSequence(dataOnly), true);
+});
+
+Deno.test("isSSEEventSequence: rejects non-array", () => {
+  assertEquals(isSSEEventSequence({ data: "test" }), false);
+  assertEquals(isSSEEventSequence("test"), false);
+  assertEquals(isSSEEventSequence(null), false);
+});
+
+Deno.test("isSSEEventSequence: rejects empty array", () => {
+  assertEquals(isSSEEventSequence([]), false);
+});
+
+Deno.test("isSSEEventSequence: rejects array without event/data fields", () => {
+  const invalidSequence = [
+    { text: "Hello" },
+    { text: "World" },
+  ];
+  assertEquals(isSSEEventSequence(invalidSequence), false);
+});
+
+Deno.test("createStreamingResponse: SSE with example event sequence", async () => {
+  const doc = { type: "object" };
+  const registry = new SchemaRegistry({ schema: doc });
+
+  const exampleEvents = [
+    { event: "start", data: { message: "Starting..." } },
+    { event: "progress", data: { percent: 50 } },
+    { event: "complete", data: { result: "success" } },
+  ];
+
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { example: exampleEvents, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  // Should have the three events
+  assertStringIncludes(fullText, "event: start");
+  assertStringIncludes(fullText, "event: progress");
+  assertStringIncludes(fullText, "event: complete");
+  assertStringIncludes(fullText, '"message":"Starting..."');
+  assertStringIncludes(fullText, '"percent":50');
+  assertStringIncludes(fullText, '"result":"success"');
+
+  // Should NOT have auto-added done event (last event is "complete")
+  // Count occurrences of "event: done" - should be 0
+  const doneMatches = fullText.match(/event: done/g);
+  assertEquals(doneMatches, null);
+});
+
+Deno.test("createStreamingResponse: SSE adds done event if missing", async () => {
+  const doc = { type: "object" };
+  const registry = new SchemaRegistry({ schema: doc });
+
+  const exampleEvents = [
+    { event: "message", data: { text: "Hello" } },
+    { event: "message", data: { text: "World" } },
+  ];
+
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { example: exampleEvents, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  // Should have auto-added done event since last wasn't done/complete/end
+  assertStringIncludes(fullText, "event: done");
+});
+
+Deno.test("createStreamingResponse: SSE supports custom event IDs", async () => {
+  const doc = { type: "object" };
+  const registry = new SchemaRegistry({ schema: doc });
+
+  const exampleEvents = [
+    { id: "evt-001", event: "message", data: { text: "Hello" } },
+    { id: "evt-002", event: "done", data: {} },
+  ];
+
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { example: exampleEvents, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  assertStringIncludes(fullText, "id: evt-001");
+  assertStringIncludes(fullText, "id: evt-002");
+});
+
+Deno.test("createStreamingResponse: SSE supports retry field", async () => {
+  const doc = { type: "object" };
+  const registry = new SchemaRegistry({ schema: doc });
+
+  const exampleEvents = [
+    { event: "message", data: { text: "Hello" }, retry: 5000 },
+    { event: "done", data: {} },
+  ];
+
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { example: exampleEvents, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  assertStringIncludes(fullText, "retry: 5000");
+});
+
+Deno.test("createStreamingResponse: SSE schema-based adds done event", async () => {
+  const doc = {
+    type: "object",
+    properties: { value: { type: "integer" } },
+  };
+
+  const registry = new SchemaRegistry({ schema: doc });
+  const stream = createStreamingResponse(
+    registry,
+    doc,
+    "#/schema",
+    "sse",
+    { count: 2, interval: 0 },
+  );
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let fullText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fullText += decoder.decode(value);
+  }
+
+  // Schema-based SSE should end with done event
+  assertStringIncludes(fullText, "event: done\ndata: {}");
+});

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,0 +1,402 @@
+/**
+ * Streaming response generator for NDJSON and SSE formats
+ *
+ * Supports:
+ * - application/x-ndjson: Newline-delimited JSON (each line is a complete JSON object)
+ * - text/event-stream: Server-Sent Events (data: {...}\n\n format)
+ *
+ * SSE Examples:
+ * - Single object example: generates multiple events from schema
+ * - Array example: each item is an SSE event with optional event/id/retry fields
+ */
+
+import type { SchemaRegistry } from "@steady/json-schema";
+import { RegistryResponseGenerator } from "@steady/json-schema";
+import type { GenerateOptions } from "@steady/json-schema";
+
+/** Streaming content types that trigger streaming behavior */
+export const STREAMING_CONTENT_TYPES = [
+  "application/x-ndjson",
+  "application/jsonl",
+  "application/json-seq",
+  "text/event-stream",
+] as const;
+
+export type StreamingContentType = typeof STREAMING_CONTENT_TYPES[number];
+
+/**
+ * SSE event structure for examples.
+ * Supports the standard SSE fields: event, data, id, retry
+ */
+export interface SSEEvent {
+  /** Event type name (default: "message") */
+  event?: string;
+  /** Event data payload */
+  data: unknown;
+  /** Event ID for client tracking */
+  id?: string | number;
+  /** Retry timeout in milliseconds */
+  retry?: number;
+}
+
+/** Check if a content type is a streaming type */
+export function isStreamingContentType(
+  contentType: string,
+): contentType is StreamingContentType {
+  const normalized = contentType.toLowerCase().split(";")[0]?.trim() ?? "";
+  return STREAMING_CONTENT_TYPES.includes(normalized as StreamingContentType);
+}
+
+/** Get the streaming format for a content type */
+export function getStreamFormat(
+  contentType: string,
+): "ndjson" | "sse" | null {
+  const normalized = contentType.toLowerCase().split(";")[0]?.trim() ?? "";
+  if (
+    normalized === "application/x-ndjson" ||
+    normalized === "application/jsonl" ||
+    normalized === "application/json-seq"
+  ) {
+    return "ndjson";
+  }
+  if (normalized === "text/event-stream") {
+    return "sse";
+  }
+  return null;
+}
+
+export interface StreamingOptions {
+  /** Number of items to stream (default: 5) */
+  count?: number;
+  /** Interval between items in milliseconds (default: 100) */
+  interval?: number;
+  /** Generator options for creating items */
+  generatorOptions?: GenerateOptions;
+  /** Pre-defined example events (for SSE) */
+  example?: unknown;
+}
+
+const DEFAULT_STREAM_COUNT = 5;
+const DEFAULT_STREAM_INTERVAL = 100;
+
+/**
+ * Check if an example is an SSE event sequence (array of events with data fields)
+ */
+export function isSSEEventSequence(example: unknown): example is SSEEvent[] {
+  if (!Array.isArray(example) || example.length === 0) {
+    return false;
+  }
+  // Check if items look like SSE events (have data field or event field)
+  return example.every(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      ("data" in item || "event" in item),
+  );
+}
+
+/**
+ * Creates a streaming response body as a ReadableStream
+ */
+export function createStreamingResponse(
+  registry: SchemaRegistry,
+  schema: unknown,
+  schemaPointer: string,
+  format: "ndjson" | "sse",
+  options: StreamingOptions = {},
+): ReadableStream<Uint8Array> {
+  // For SSE with event sequence examples, use the example-based streaming
+  if (
+    format === "sse" && options.example && isSSEEventSequence(options.example)
+  ) {
+    return createSSEFromExample(options.example, options);
+  }
+
+  // Otherwise, generate from schema
+  return createStreamFromSchema(
+    registry,
+    schema,
+    schemaPointer,
+    format,
+    options,
+  );
+}
+
+/**
+ * Create SSE stream from a pre-defined event sequence example
+ */
+function createSSEFromExample(
+  events: SSEEvent[],
+  options: StreamingOptions,
+): ReadableStream<Uint8Array> {
+  const interval = options.interval ?? DEFAULT_STREAM_INTERVAL;
+  const encoder = new TextEncoder();
+  let eventIndex = 0;
+  let cancelled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emitEvent = () => {
+        if (cancelled || eventIndex >= events.length) {
+          // Check if last event was a "done" type - if not, add one
+          const lastEvent = events[events.length - 1];
+          const lastEventType = lastEvent?.event?.toLowerCase();
+          if (
+            !cancelled && lastEventType !== "done" &&
+            lastEventType !== "complete" && lastEventType !== "end"
+          ) {
+            controller.enqueue(encoder.encode("event: done\ndata: {}\n\n"));
+          }
+          controller.close();
+          return;
+        }
+
+        const event = events[eventIndex]!;
+        const formatted = formatSSEEvent(event, eventIndex);
+        controller.enqueue(encoder.encode(formatted));
+
+        eventIndex++;
+
+        // Schedule next event
+        if (eventIndex < events.length && !cancelled) {
+          timeoutId = setTimeout(emitEvent, interval);
+        } else if (!cancelled) {
+          // Check if we need to add a done event
+          const lastEvent = events[events.length - 1];
+          const lastEventType = lastEvent?.event?.toLowerCase();
+          if (
+            lastEventType !== "done" && lastEventType !== "complete" &&
+            lastEventType !== "end"
+          ) {
+            controller.enqueue(encoder.encode("event: done\ndata: {}\n\n"));
+          }
+          controller.close();
+        }
+      };
+
+      // Start emitting
+      emitEvent();
+    },
+    cancel() {
+      cancelled = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    },
+  });
+}
+
+/**
+ * Format an SSE event from an example
+ *
+ * Supports OpenAI-style events where:
+ * - event: null or "" skips the event line (for data-only events like [DONE])
+ * - id: null skips the id line
+ * - String data is output as-is (not JSON encoded)
+ */
+function formatSSEEvent(event: SSEEvent, index: number): string {
+  const lines: string[] = [];
+
+  // Add ID unless explicitly null (use provided or auto-generate)
+  if (event.id !== null) {
+    const id = event.id ?? index;
+    lines.push(`id: ${id}`);
+  }
+
+  // Add retry if specified
+  if (event.retry !== undefined) {
+    lines.push(`retry: ${event.retry}`);
+  }
+
+  // Add event type - skip if null or empty string (for OpenAI-style [DONE])
+  if (event.event !== null && event.event !== "") {
+    const eventType = event.event ?? "message";
+    lines.push(`event: ${eventType}`);
+  }
+
+  // Add data - strings output as-is, objects JSON encoded
+  const data = typeof event.data === "string"
+    ? event.data
+    : JSON.stringify(event.data);
+
+  // Handle multi-line data (each line needs "data: " prefix)
+  const dataLines = data.split("\n");
+  for (const line of dataLines) {
+    lines.push(`data: ${line}`);
+  }
+
+  // End with double newline
+  return lines.join("\n") + "\n\n";
+}
+
+/**
+ * Create stream from schema (original behavior)
+ */
+function createStreamFromSchema(
+  registry: SchemaRegistry,
+  schema: unknown,
+  schemaPointer: string,
+  format: "ndjson" | "sse",
+  options: StreamingOptions,
+): ReadableStream<Uint8Array> {
+  const count = options.count ?? DEFAULT_STREAM_COUNT;
+  const interval = options.interval ?? DEFAULT_STREAM_INTERVAL;
+  const generatorOptions = options.generatorOptions ?? {};
+
+  // For deterministic streaming, we increment the seed for each item
+  const baseSeed = generatorOptions.seed ?? 123456789;
+
+  const encoder = new TextEncoder();
+  let itemIndex = 0;
+  let cancelled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emitItem = () => {
+        if (cancelled || itemIndex >= count) {
+          // Send done event for SSE
+          if (format === "sse" && !cancelled) {
+            controller.enqueue(encoder.encode("event: done\ndata: {}\n\n"));
+          }
+          controller.close();
+          return;
+        }
+
+        // Create generator with incremented seed for this item
+        const itemSeed = baseSeed + itemIndex;
+        const generator = new RegistryResponseGenerator(registry, {
+          ...generatorOptions,
+          seed: itemSeed,
+        });
+
+        let item: unknown;
+        if (typeof schema === "object" && schema !== null && "$ref" in schema) {
+          const ref = (schema as { $ref: string }).$ref;
+          const resolved = registry.resolveRef(ref);
+          if (resolved) {
+            item = generator.generateFromSchema(resolved.raw, ref, 0);
+          } else {
+            item = { error: `Unresolved reference: ${ref}` };
+          }
+        } else {
+          item = generator.generateFromSchema(
+            schema as Parameters<
+              RegistryResponseGenerator["generateFromSchema"]
+            >[0],
+            schemaPointer,
+            0,
+          );
+        }
+
+        // Format the item based on stream type
+        const formatted = formatSchemaStreamItem(
+          item,
+          format,
+          itemIndex,
+          count,
+        );
+        controller.enqueue(encoder.encode(formatted));
+
+        itemIndex++;
+
+        // Schedule next item
+        if (itemIndex < count && !cancelled) {
+          timeoutId = setTimeout(emitItem, interval);
+        } else if (!cancelled) {
+          // Send done event for SSE
+          if (format === "sse") {
+            controller.enqueue(encoder.encode("event: done\ndata: {}\n\n"));
+          }
+          controller.close();
+        }
+      };
+
+      // Start emitting
+      emitItem();
+    },
+    cancel() {
+      cancelled = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    },
+  });
+}
+
+/**
+ * Format a schema-generated item for streaming output
+ */
+function formatSchemaStreamItem(
+  item: unknown,
+  format: "ndjson" | "sse",
+  index: number,
+  total: number,
+): string {
+  if (format === "sse") {
+    // For SSE, wrap in proper event format
+    const json = JSON.stringify(item);
+    return `id: ${index}\nevent: message\ndata: ${json}\n\n`;
+  }
+
+  // NDJSON format: add metadata and output as JSON line
+  const itemWithMeta = addStreamingMetadata(item, index, total);
+  return JSON.stringify(itemWithMeta) + "\n";
+}
+
+/**
+ * Add streaming metadata to an item (for NDJSON)
+ */
+function addStreamingMetadata(
+  item: unknown,
+  index: number,
+  total: number,
+): unknown {
+  // If item is an object, add metadata fields
+  if (typeof item === "object" && item !== null && !Array.isArray(item)) {
+    return {
+      ...(item as Record<string, unknown>),
+      _stream: {
+        index,
+        total,
+        timestamp: new Date().toISOString(),
+      },
+    };
+  }
+  // For non-objects, wrap in an object
+  return {
+    data: item,
+    _stream: {
+      index,
+      total,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Parse streaming options from request headers
+ */
+export function parseStreamingOptions(req: Request): StreamingOptions {
+  const countHeader = req.headers.get("X-Steady-Stream-Count");
+  const intervalHeader = req.headers.get("X-Steady-Stream-Interval-Ms");
+
+  const options: StreamingOptions = {};
+
+  if (countHeader) {
+    const count = parseInt(countHeader, 10);
+    if (!isNaN(count) && count > 0 && count <= 1000) {
+      options.count = count;
+    }
+  }
+
+  if (intervalHeader) {
+    const interval = parseInt(intervalHeader, 10);
+    if (!isNaN(interval) && interval >= 0 && interval <= 10000) {
+      options.interval = interval;
+    }
+  }
+
+  return options;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export const HEADERS = {
   ARRAY_MAX: "X-Steady-Array-Max",
   /** Override seed for deterministic generation (-1 for random) */
   SEED: "X-Steady-Seed",
+  /** Number of items to stream for streaming responses (default: 5) */
+  STREAM_COUNT: "X-Steady-Stream-Count",
+  /** Interval in milliseconds between streamed items (default: 100) */
+  STREAM_INTERVAL_MS: "X-Steady-Stream-Interval-Ms",
 
   // Response headers (informational)
   /** The OpenAPI path pattern that matched the request */
@@ -41,6 +45,8 @@ export const HEADERS = {
   EXAMPLE_SOURCE: "X-Steady-Example-Source",
   /** Indicates a serialization error occurred (set to "true") */
   SERIALIZATION_ERROR: "X-Steady-Serialization-Error",
+  /** Indicates the response is being streamed */
+  STREAMING: "X-Steady-Streaming",
 } as const;
 
 export interface ResolvedOperation {

--- a/test-fixtures/streaming-test.yaml
+++ b/test-fixtures/streaming-test.yaml
@@ -1,0 +1,129 @@
+openapi: "3.1.0"
+info:
+  title: Streaming Test API
+  version: "1.0.0"
+  description: Test API for NDJSON and SSE streaming
+
+paths:
+  /events:
+    get:
+      summary: Get events as SSE stream (schema-based)
+      description: Returns events as Server-Sent Events generated from schema
+      responses:
+        "200":
+          description: SSE event stream
+          content:
+            text/event-stream:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  type:
+                    type: string
+                    enum: ["created", "updated", "deleted"]
+                  timestamp:
+                    type: string
+                    format: date-time
+                  data:
+                    type: object
+                    additionalProperties: true
+                required:
+                  - id
+                  - type
+                  - timestamp
+
+  /process:
+    post:
+      summary: Process data with SSE progress updates
+      description: Demonstrates SSE with event sequence example
+      responses:
+        "200":
+          description: SSE progress stream
+          content:
+            text/event-stream:
+              example:
+                - event: started
+                  data: { message: "Processing started", jobId: "job-123" }
+                - event: progress
+                  data: { percent: 25, stage: "validation" }
+                - event: progress
+                  data: { percent: 50, stage: "transformation" }
+                - event: progress
+                  data: { percent: 75, stage: "saving" }
+                - event: progress
+                  data: { percent: 100, stage: "complete" }
+                - event: done
+                  data: { success: true, result: { itemsProcessed: 42 } }
+
+  /stream-json:
+    get:
+      summary: Stream JSON objects
+      description: Streams JSON objects as a chunked response (NDJSON)
+      responses:
+        "200":
+          description: Chunked JSON stream
+          content:
+            application/x-ndjson:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  timestamp:
+                    type: string
+                    format: date-time
+                  value:
+                    type: number
+                required:
+                  - id
+                  - value
+
+  /metrics:
+    get:
+      summary: Stream metrics data
+      description: Streams metrics as JSON lines
+      responses:
+        "200":
+          description: Metrics stream
+          content:
+            application/jsonl:
+              schema:
+                type: object
+                properties:
+                  metric:
+                    type: string
+                  value:
+                    type: number
+                  tags:
+                    type: object
+                    additionalProperties:
+                      type: string
+                required:
+                  - metric
+                  - value
+
+  /users:
+    get:
+      summary: Get users (non-streaming)
+      description: Regular JSON endpoint for comparison
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    email:
+                      type: string
+                      format: email
+                  required:
+                    - id
+                    - name


### PR DESCRIPTION
Adds streaming response support for:
- NDJSON formats: application/x-ndjson, application/jsonl, application/json-seq
- Server-Sent Events: text/event-stream

Features:
- Schema-based streaming generates items from JSON Schema
- Example-based SSE supports event sequences with different event types
- OpenAI-style SSE pattern (data-only events like [DONE])
- Configurable stream count and interval via headers
- Auto-appends done event for SSE stream completion
- Deterministic streaming with seeded RNG

Headers:
- X-Steady-Stream-Count: Number of items (default: 5, max: 1000)
- X-Steady-Stream-Interval-Ms: Delay between items (default: 100ms)