### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/logging/format-expected.ts
+++ b/src/logging/format-expected.ts
@@ -176,7 +176,7 @@ export function formatPath(instancePath: string): string {
 
       // Check if property name needs quoting (contains dots or special chars)
       if (/[.\[\]"]/.test(unescaped)) {
-        return `["${unescaped.replace(/"/g, '\\"')}"]`;
+        return `["${unescaped.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`;
       }
 
       // Regular property name


### PR DESCRIPTION
Potential fix for [https://github.com/dgellow/steady/security/code-scanning/7](https://github.com/dgellow/steady/security/code-scanning/7)

In general, when building a quoted representation like `["..."]`, every character that has special meaning in that string syntax (notably `\` and `"`) should be escaped. Here we already escape `"`, but we must escape `\` first; otherwise, sequences like `\"` will turn into `\\"`, which might be interpreted differently than intended.

The best fix is to modify the line that currently does `unescaped.replace(/"/g, '\\"')` so that it first escapes all backslashes, and then escapes double quotes. This ensures:
- All literal backslashes become `\\`.
- All literal double quotes become `\"`.
- The resulting `["..."]`-style segment is a proper, self-contained representation.

We only need to change line 179 in `src/logging/format-expected.ts` within the `formatPath` function. No new imports or helper functions are required; we can use standard JavaScript string `replace` with regular expressions.

Concretely, change:

```ts
return `["${unescaped.replace(/"/g, '\\"')}"]`;
```

to:

```ts
return `["${unescaped.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`;
```

so backslashes are escaped before quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
