### PR TITLE
feat: log request body with --log-bodies flag

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -481,6 +481,7 @@ export class MockServer {
       valid: boolean;
       errors: import("./types.ts").ValidationIssue[];
       warnings: import("./types.ts").ValidationIssue[];
+      requestBody?: unknown;
     },
     responseHeaders?: Headers,
     responseBody?: unknown,
@@ -497,6 +498,7 @@ export class MockServer {
         pathPattern,
         query: url.search,
         headers: req.headers,
+        body: validation?.requestBody,
       },
       response: {
         status,

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -62,6 +62,7 @@ export interface ValidationResult {
   valid: boolean;
   errors: ValidationIssue[];
   warnings: ValidationIssue[];
+  requestBody?: unknown;
 }
 
 /**
@@ -230,22 +231,25 @@ export class RequestValidator {
     }
 
     // Validate request body (if spec defines one, validate it regardless of HTTP method)
-    const requestBody = getResolvedRequestBody(operation.requestBody);
-    if (requestBody) {
+    let parsedRequestBody: unknown;
+    const requestBodySpec = getResolvedRequestBody(operation.requestBody);
+    if (requestBodySpec) {
       const bodyValidation = await this.validateRequestBodyFromRequest(
         req,
-        requestBody,
+        requestBodySpec,
         effectiveFormArrayFormat,
         effectiveFormObjectFormat,
       );
       errors.push(...bodyValidation.errors);
       warnings.push(...bodyValidation.warnings);
+      parsedRequestBody = bodyValidation.requestBody;
     }
 
     return {
       valid: errors.length === 0,
       errors,
       warnings,
+      requestBody: parsedRequestBody,
     };
   }
 
@@ -932,7 +936,7 @@ export class RequestValidator {
       );
       this.collectErrors(validation, errors);
 
-      return { valid: errors.length === 0, errors, warnings };
+      return { valid: errors.length === 0, errors, warnings, requestBody: parsedBody };
     } catch (error) {
       if (error instanceof BodyTooLargeError) {
         errors.push({


### PR DESCRIPTION
The validator now returns the parsed request body in ValidationResult, which is then passed to the logger for display when --log-bodies is set.

Changes:
- Add requestBody field to ValidationResult in validator.ts
- Return parsed body from validateRequestBodyFromRequest
- Pass request body through logRequestEvent to the event