### PR TITLE
fix: handle SIGTERM/SIGHUP for graceful server shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
           npx steady validate ${{ github.workspace }}/tests/specs/simple.yaml
           npx steady --help
 
+      - name: Package tests
+        run: ./tests/process-cleanup.sh
+
   test-sdks:
     name: SDK Integration Tests
     runs-on: ubuntu-latest

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -154,9 +154,10 @@ await Deno.mkdir(mainPkgDir, { recursive: true });
 
 // Create the JavaScript wrapper
 const wrapperCode = `#!/usr/bin/env node
-const { execFileSync } = require("child_process");
+const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
 
 const platform = process.platform;
 const arch = process.arch;
@@ -211,14 +212,21 @@ if (!binPath) {
   }
 }
 
-try {
-  execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
-} catch (e) {
-  if (e.status !== undefined) {
-    process.exit(e.status);
-  }
-  throw e;
+const child = spawn(binPath, process.argv.slice(2), { stdio: "inherit" });
+
+child.on("error", (err) => {
+  console.error(\`Failed to start steady: \${err.message}\`);
+  process.exit(1);
+});
+
+for (const sig of Object.keys(os.constants.signals)) {
+  try { process.on(sig, () => child.kill(sig)); } catch {}
 }
+
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});
 `;
 
 await Deno.writeTextFile(`${mainPkgDir}/steady.js`, wrapperCode);

--- a/scripts/test-sdks.ts
+++ b/scripts/test-sdks.ts
@@ -227,6 +227,7 @@ async function createMockScript(
 
   const validatorFlags = sdk.validatorFlags?.join(" ") ?? "";
 
+  // Use deno run directly instead of deno task to avoid spawning child processes
   const mockScript = `#!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")/.."
@@ -236,7 +237,7 @@ SPEC="${specPath}"
 echo "==> Starting Steady mock server with spec \${SPEC}"
 
 if [ "$1" == "--daemon" ]; then
-  deno task --cwd "${STEADY_DIR}" start --host 0.0.0.0 --port ${PORT} ${validatorFlags} "\${SPEC}" &> .steady.log &
+  deno run --allow-read --allow-net --allow-env --allow-write "${STEADY_DIR}/cmd/steady.ts" --host 0.0.0.0 --port ${PORT} ${validatorFlags} "\${SPEC}" &> .steady.log &
 
   # Wait for server to come online
   echo -n "Waiting for server"
@@ -253,7 +254,7 @@ if [ "$1" == "--daemon" ]; then
   cat .steady.log
   exit 1
 else
-  deno task --cwd "${STEADY_DIR}" start --host 0.0.0.0 --port ${PORT} ${validatorFlags} "\${SPEC}"
+  deno run --allow-read --allow-net --allow-env --allow-write "${STEADY_DIR}/cmd/steady.ts" --host 0.0.0.0 --port ${PORT} ${validatorFlags} "\${SPEC}"
 fi
 `;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,7 +207,7 @@ export class MockServer {
     this.serverFinished = server.finished;
 
     // Handle graceful shutdown
-    Deno.addSignalListener("SIGINT", () => {
+    const handleShutdown = () => {
       // Stop TUI if running
       if (this.config.interactive && this.logger instanceof TuiLogger) {
         this.logger.stop();
@@ -215,7 +215,15 @@ export class MockServer {
       this.logShutdown();
       this.stop();
       Deno.exit(0);
-    });
+    };
+    // Handle common shutdown signals
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"] as const) {
+      try {
+        Deno.addSignalListener(signal, handleShutdown);
+      } catch {
+        // Signal not supported on this platform
+      }
+    }
   }
 
   /**

--- a/tests/process-cleanup.sh
+++ b/tests/process-cleanup.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+
+TEST_PORT=19876
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Create temp spec file
+SPEC_FILE=$(mktemp --suffix=.yaml)
+cat > "$SPEC_FILE" << 'EOF'
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      responses:
+        "200":
+          description: OK
+EOF
+
+cleanup() {
+  rm -f "$SPEC_FILE"
+  for i in {0..5}; do
+    kill -9 $(lsof -t -i:$((TEST_PORT + i)) 2>/dev/null) 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+test_signal() {
+  local mode=$1
+  local signal=$2
+  local port=$3
+  echo "Testing $mode with $signal on port $port..."
+
+  if [ "$mode" = "deno" ]; then
+    deno run --allow-read --allow-net --allow-env cmd/steady.ts --no-log --port "$port" "$SPEC_FILE" >/dev/null 2>&1 &
+  elif [ "$mode" = "npm" ]; then
+    node npm/cli/steady.js --no-log --port "$port" "$SPEC_FILE" >/dev/null 2>&1 &
+  fi
+  SERVER_PID=$!
+
+  # Wait for server to start
+  for i in {1..50}; do
+    if curl -s "http://localhost:$port/health" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  if ! curl -s "http://localhost:$port/health" >/dev/null 2>&1; then
+    echo "  FAIL: Server did not start"
+    kill $SERVER_PID 2>/dev/null || true
+    return 1
+  fi
+
+  echo "  Server started (PID $SERVER_PID)"
+
+  # Send signal
+  kill -"$signal" $SERVER_PID
+  echo "  Sent $signal to $SERVER_PID"
+
+  # Wait for process to exit
+  for i in {1..50}; do
+    if ! kill -0 $SERVER_PID 2>/dev/null; then
+      echo "  PASS: Process exited after $signal"
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "  FAIL: Process still running after $signal"
+  kill -9 $SERVER_PID 2>/dev/null || true
+  return 1
+}
+
+# Check npm package exists
+if [ ! -f "npm/cli/steady.js" ]; then
+  echo "Building npm package first..."
+  deno run -A scripts/build_npm.ts --platform linux-x64 >/dev/null 2>&1
+fi
+
+echo "=== Process Cleanup Tests ==="
+echo
+
+echo "--- Deno direct ---"
+test_signal deno TERM $TEST_PORT
+test_signal deno INT $((TEST_PORT + 1))
+test_signal deno HUP $((TEST_PORT + 2))
+
+echo
+echo "--- npm wrapper ---"
+test_signal npm TERM $((TEST_PORT + 3))
+test_signal npm INT $((TEST_PORT + 4))
+test_signal npm HUP $((TEST_PORT + 5))
+
+echo
+echo "All tests passed!"


### PR DESCRIPTION
- Server handles common shutdown signals (SIGINT, SIGTERM, SIGHUP, SIGQUIT)
- npm wrapper forwards all signals to child (transparent wrapper)
- Added bash test script for process cleanup (tests both deno and npm)