### PR TITLE
fix: group append array entries by full sub-path, coerce additionalProperties values

### DIFF
--- a/src/form-parser.test.ts
+++ b/src/form-parser.test.ts
@@ -1275,3 +1275,52 @@ Deno.test("parseUrlEncoded: brackets+brackets deep nested array-of-objects", () 
 });
 
 console.log("Form parser tests loaded");
+
+Deno.test("parseFormData: brackets array element with multi-key nested maps stays one element", async () => {
+  const formData = new FormData();
+  formData.append("entries[][direction]", "credit");
+  formData.append("entries[][amount]", "0");
+  formData.append("entries[][metadata][key]", "value");
+  formData.append("entries[][metadata][foo]", "bar");
+  formData.append("entries[][balances][cash]", "25");
+
+  const result = await parseFormData(formData, {
+    formArrayFormat: "brackets",
+    formObjectFormat: "brackets",
+    schema: {
+      type: "object",
+      properties: {
+        entries: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["direction", "amount"],
+            properties: {
+              direction: { type: "string" },
+              amount: { type: "integer" },
+              metadata: {
+                type: "object",
+                additionalProperties: { type: "string" },
+              },
+              balances: {
+                type: "object",
+                additionalProperties: { type: "integer" },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assertEquals(result.data, {
+    entries: [
+      {
+        direction: "credit",
+        amount: 0,
+        metadata: { key: "value", foo: "bar" },
+        balances: { cash: 25 },
+      },
+    ],
+  });
+});

--- a/src/param-format.test.ts
+++ b/src/param-format.test.ts
@@ -951,3 +951,172 @@ Deno.test("parseFormEntries: $ref in property schema resolves via resolver callb
 });
 
 console.log("param-format tests loaded");
+
+// =============================================================================
+// Append grouping boundaries (Rack semantics)
+// =============================================================================
+
+// A single element whose nested object carries several keys must stay one
+// element: the element boundary is a repeat of the full sub-path, not of the
+// first segment name. (SDKs serialize `entries[][metadata][k]` once per map
+// key; Rack-style parsers merge these into the same element.)
+Deno.test("parseFormEntries: append element with multi-key nested object stays one element", () => {
+  const entries: [string, string][] = [
+    ["entries[][direction]", "credit"],
+    ["entries[][amount]", "0"],
+    ["entries[][metadata][key]", "value"],
+    ["entries[][metadata][foo]", "bar"],
+    ["entries[][metadata][extra]", "data"],
+    ["entries[][balances][cash]", "1"],
+  ];
+  const wrapperSchema: Schema = {
+    type: "object",
+    properties: {
+      entries: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            direction: { type: "string" },
+            amount: { type: "integer" },
+            metadata: {
+              type: "object",
+              additionalProperties: { type: "string" },
+            },
+            balances: {
+              type: "object",
+              additionalProperties: { type: "integer" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = parseFormEntries(entries, wrapperSchema, BRACKETS);
+  assertEquals(result, {
+    entries: [
+      {
+        direction: "credit",
+        amount: 0,
+        metadata: { key: "value", foo: "bar", extra: "data" },
+        balances: { cash: 1 },
+      },
+    ],
+  });
+});
+
+Deno.test("parseFormEntries: append starts a new element on full sub-path repeat", () => {
+  const entries: [string, string][] = [
+    ["entries[][meta][a]", "1"],
+    ["entries[][meta][b]", "2"],
+    ["entries[][meta][a]", "3"],
+  ];
+  const wrapperSchema: Schema = {
+    type: "object",
+    properties: {
+      entries: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            meta: { type: "object", additionalProperties: { type: "string" } },
+          },
+        },
+      },
+    },
+  };
+
+  const result = parseFormEntries(entries, wrapperSchema, BRACKETS);
+  assertEquals(result, {
+    entries: [
+      { meta: { a: "1", b: "2" } },
+      { meta: { a: "3" } },
+    ],
+  });
+});
+
+Deno.test("parseFormEntries: nested append inside an element never starts a new element", () => {
+  const entries: [string, string][] = [
+    ["entries[][tags][]", "x"],
+    ["entries[][tags][]", "y"],
+    ["entries[][name]", "a"],
+  ];
+  const wrapperSchema: Schema = {
+    type: "object",
+    properties: {
+      entries: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            tags: { type: "array", items: { type: "string" } },
+            name: { type: "string" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = parseFormEntries(entries, wrapperSchema, BRACKETS);
+  assertEquals(result, {
+    entries: [{ tags: ["x", "y"], name: "a" }],
+  });
+});
+
+// =============================================================================
+// additionalProperties coercion
+// =============================================================================
+
+Deno.test("parseFormEntries: coerces values under additionalProperties schema", () => {
+  const entries: [string, string][] = [
+    ["balances[cash]", "0"],
+    ["balances[credit]", "25"],
+  ];
+  const wrapperSchema: Schema = {
+    type: "object",
+    properties: {
+      balances: { type: "object", additionalProperties: { type: "integer" } },
+    },
+  };
+
+  const result = parseFormEntries(entries, wrapperSchema, BRACKETS);
+  assertEquals(result, { balances: { cash: 0, credit: 25 } });
+});
+
+Deno.test("parseFormEntries: multiple append elements each with multi-key nested objects", () => {
+  const entries: [string, string][] = [
+    ["entries[][name]", "a"],
+    ["entries[][meta][x]", "1"],
+    ["entries[][meta][y]", "2"],
+    ["entries[][name]", "b"],
+    ["entries[][meta][x]", "3"],
+    ["entries[][meta][y]", "4"],
+  ];
+  const wrapperSchema: Schema = {
+    type: "object",
+    properties: {
+      entries: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            meta: {
+              type: "object",
+              additionalProperties: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = parseFormEntries(entries, wrapperSchema, BRACKETS);
+  assertEquals(result, {
+    entries: [
+      { name: "a", meta: { x: "1", y: "2" } },
+      { name: "b", meta: { x: "3", y: "4" } },
+    ],
+  });
+});

--- a/src/param-format.ts
+++ b/src/param-format.ts
@@ -812,8 +812,11 @@ function assembleIndexedArray(
 
 /**
  * Group append entries into array elements by detecting property boundaries.
- * A new element starts when a property name that was already set on the
- * current element appears again.
+ * A new element starts when a sub-path that was already set on the current
+ * element appears again (Rack semantics): `a[][meta][x]` and `a[][meta][y]`
+ * belong to the same element, while a second `a[][meta][x]` starts a new one.
+ * Sub-paths containing a nested append (`a[][tags][]`) accumulate into the
+ * current element and never start a new one.
  */
 function groupAppendEntries(
   entries: KeyEntry[],
@@ -827,13 +830,21 @@ function groupAppendEntries(
   for (const entry of entries) {
     const seg = entry.segments[0];
     if (!seg || seg.type !== "key") continue;
-    const key = seg.name;
 
-    if (seen.has(key)) {
-      elements.push([]);
-      seen.clear();
+    const hasNestedAppend = entry.segments.some((s) => s.type === "append");
+    const path = entry.segments
+      .map((s) =>
+        s.type === "key" ? s.name : s.type === "index" ? String(s.index) : "[]"
+      )
+      .join(".");
+
+    if (!hasNestedAppend) {
+      if (seen.has(path)) {
+        elements.push([]);
+        seen.clear();
+      }
+      seen.add(path);
     }
-    seen.add(key);
     const current = elements[elements.length - 1];
     if (current) current.push(entry);
   }
@@ -862,9 +873,15 @@ function assembleObject(
     groups.set(seg.name, group);
   }
 
+  // Keys not declared in `properties` fall back to the `additionalProperties`
+  // schema (when it's a schema object) so map values still get type coercion.
+  const additional = resolved && isPlainObject(resolved.additionalProperties)
+    ? resolved.additionalProperties as Schema
+    : null;
+
   const result: Record<string, unknown> = Object.create(null);
   for (const [key, subEntries] of groups) {
-    const propSchema = resolve(props?.[key] ?? null, resolver) ?? null;
+    const propSchema = resolve(props?.[key] ?? additional, resolver) ?? null;
     result[key] = assembleValue(subEntries, propSchema, format, resolver);
   }
   return result;


### PR DESCRIPTION
## Problem

When an SDK serializes an array of objects with bracket/append notation, a single element that carries a multi-key nested object gets split into several fabricated elements:

```
entries[][direction]=credit
entries[][amount]=0
entries[][metadata][key]=value
entries[][metadata][foo]=bar
entries[][metadata][extra]=data
```

`groupAppendEntries` starts a new element whenever the *first* key segment repeats, so the three `metadata` keys produce three elements: `[{direction, amount, metadata: {key}}, {metadata: {foo}}, {metadata: {extra}}]`. Validation then reports the fragments as missing required properties (`E3007`) and "no variant matched" (`E3012`) — attributed as SDK bugs when the request is actually well-formed Rack-style encoding (Rails parses the payload above as one element).

Separately, values under `additionalProperties` get no schema during coercion, so map values typed `integer` arrive as strings and fail validation with `E3008`.

## Fix

Both changes are confined to `src/param-format.ts`:

- `groupAppendEntries`: group by the full sub-path instead of the first segment, matching Rack semantics — a new element starts only when a full sub-path repeats, and sub-paths containing a nested append (`a[][tags][]`) accumulate into the current element and never start a new one. Behavior for flat elements (`a[][name]`) is unchanged, since their full path equals their first segment.
- `assembleObject`: when a key isn't declared in `properties`, fall back to the `additionalProperties` schema (when it's a schema object) for value coercion.

## Testing

- 5 new `parseFormEntries` tests: multi-key nested object stays one element, boundary on full sub-path repeat, nested append never splits, multiple elements each with multi-key nested maps, and `additionalProperties` coercion. All fail on `main`.
- 1 end-to-end `parseFormData` multipart test with brackets formats and a schema mixing required properties, a string map, and an integer map.
- Full suite (`./scripts/test`, submodules initialized): 972 passed, 0 failed. `./scripts/lint` and `./scripts/format` clean.
- Verified against a real generated Java SDK test suite that previously failed with the fabricated-element errors above: full suite passes against a server built from this branch.
